### PR TITLE
fix: auto-resolve sync conflicts and preserve existing .gitignore

### DIFF
--- a/internal/gitops/gitops.go
+++ b/internal/gitops/gitops.go
@@ -206,8 +206,8 @@ func SyncToProjectDir(upstreamPath, projectDir string) (string, error) {
 		return "", fmt.Errorf("gitops: fetch failed: %w", err)
 	}
 
-	// Merge FETCH_HEAD.
-	if _, err := git(projectDir, "merge", "FETCH_HEAD", "--no-edit"); err != nil {
+	// Merge FETCH_HEAD, auto-resolving conflicts in favor of upstream (agent work).
+	if _, err := git(projectDir, "merge", "-X", "theirs", "FETCH_HEAD", "--no-edit"); err != nil {
 		if _, abortErr := git(projectDir, "merge", "--abort"); abortErr != nil {
 			slog.Warn("gitops: failed to abort merge", "error", abortErr)
 		}


### PR DESCRIPTION
## Summary
- `SyncToProjectDir` now uses `git merge -X theirs` to auto-resolve merge conflicts in favor of upstream (agent) changes, fixing `metamorph sync` failures when scaffold files (PROGRESS.md, .gitignore) diverge between the project dir and upstream
- `metamorph init` now appends to `.gitignore` instead of overwriting it, preserving any existing language-specific entries (e.g. `/target`, `Cargo.lock`)

## Test plan
- [x] Existing tests pass (`go test ./cmd/ ./internal/gitops/`)
- [x] Updated conflict test now verifies upstream content wins instead of expecting an error
- [ ] Manual test: run `metamorph init` in a project with an existing `.gitignore` and verify entries are appended, not overwritten
- [ ] Manual test: create divergent PROGRESS.md between upstream and project dir, run `metamorph sync`, verify it succeeds with upstream version

🤖 Generated with [Claude Code](https://claude.com/claude-code)